### PR TITLE
Change ZgApiResponse Error property [ZG-1045]

### DIFF
--- a/Marketplace/dotnet/Marketplace/Data/Models/ZgApiResponse.cs
+++ b/Marketplace/dotnet/Marketplace/Data/Models/ZgApiResponse.cs
@@ -9,8 +9,14 @@ namespace Marketplace.Data.Models
         
         [JsonProperty("success")]
         public bool Success { get; set; }
+
+        public Error Error { get; set; }
+    }
+
+    internal class Error
+    {
+        public string Message { get; set; }
         
-        [JsonProperty("error")]
-        public string Error { get; set; }
+        public string Details { get; set; }
     }
 }


### PR DESCRIPTION
According to https://aspnetboilerplate.com/Pages/Documents/Javascript-API/AJAX error is an object that contains the message and details fields.